### PR TITLE
netbox: fix django secret name key

### DIFF
--- a/charts/netbox/templates/deployment.yaml
+++ b/charts/netbox/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - name: SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.existingDjagonSecret }}
+                  name: {{ .Values.existingDjangoSecret }}
                   key: {{ .Values.existingDjangoSecretKey }}
           {{- end }}
           {{- if .Values.postgresql.enabled }}


### PR DESCRIPTION
Used this chart to test a NetBox deployment and spotted the following wrong key.