### PR TITLE
matrix-synapse: add securityContext for signing-key-job

### DIFF
--- a/charts/matrix-synapse/templates/signing-key-job.yaml
+++ b/charts/matrix-synapse/templates/signing-key-job.yaml
@@ -120,6 +120,8 @@ spec:
           name: signing-key-generate
           resources:
             {{- toYaml .Values.signingkey.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.signingkey.job.podSecurityContext | nindent 12 }}
           volumeMounts:
             - mountPath: /synapse/keys
               name: matrix-synapse-keys
@@ -138,6 +140,8 @@ spec:
           name: signing-key-upload
           resources:
             {{- toYaml .Values.signingkey.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.signingkey.job.podSecurityContext | nindent 12 }}
           volumeMounts:
             - mountPath: /scripts
               name: scripts
@@ -145,6 +149,8 @@ spec:
             - mountPath: /synapse/keys
               name: matrix-synapse-keys
               readOnly: true
+      securityContext:
+        {{- toYaml .Values.signingkey.job.securityContext | nindent 8 }}
       restartPolicy: Never
       serviceAccount: {{ $name }}
       volumes:

--- a/charts/matrix-synapse/values.yaml
+++ b/charts/matrix-synapse/values.yaml
@@ -68,6 +68,28 @@ signingkey:
       # tag: latest
       pullPolicy: IfNotPresent
 
+    ## Configure for pod job security policy, setting ovnership of the pod such that
+    ## synapse owns the files created by signing key job.
+    ## Synapse default UID:GID is 666:666
+    ##
+    ## Some systems will have a default owner such as root to own the files, synpase
+    ## will not be able to access the files in such a case, deppending on permissions.
+    podSecurityContext: {}
+    #  fsGroup: 666
+    #  runAsGroup: 666
+    #  runAsUser: 666
+
+    ## Configuration for the container security policy, refer to the above
+    ## podSecurityContext for more relevant information.
+    ##
+    securityContext: {}
+    #  capabilities:
+    #    drop:
+    #    - ALL
+    #  readOnlyRootFilesystem: true
+    #  runAsNonRoot: true
+    #  runAsUser: 666
+
   ## Specify an existing signing key secret, will need to be created in advance.
   ##
   # existingSecret: secret-name


### PR DESCRIPTION
Our project couldn't run it without adding securityContext options for the container and pod when running the signing-key-job, I believe the reason being that the files was owned by root. Synapse did not have permission to access the files it created.