### PR TITLE
Update Chart.yaml to bump up the Postgresql version of the bitname helm chart

### DIFF
--- a/charts/matrix-synapse/Chart.yaml
+++ b/charts/matrix-synapse/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 
 dependencies:
   - name: postgresql
-    version: ^12.1.4
+    version: ^15.5.29
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: redis


### PR DESCRIPTION
bump up version for postgresql to 15.5.29, bacause of many fixes