### PR TITLE
Fix postgresql existingSecret condition for config.yaml

### DIFF
--- a/charts/matrix-synapse/templates/secrets.yaml
+++ b/charts/matrix-synapse/templates/secrets.yaml
@@ -44,7 +44,7 @@ stringData:
       name: "psycopg2"
       args:
         user: {{ $postgresUser | quote }}
-        {{- if and $postgresPass (not .Values.postgresql.existingSecret) }}
+        {{- if and $postgresPass (not .Values.postgresql.auth.existingSecret) }}
         password: {{ $postgresPass | quote }}
         {{- else }}
         password: "@@POSTGRES_PASSWORD@@"


### PR DESCRIPTION
This was probably a typo. The condition should be `postgresql.auth.existingSecret`. :smile: