### PR TITLE
fix: while loop in peertube deployment container script

### DIFF
--- a/charts/peertube/templates/deployment.yaml
+++ b/charts/peertube/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
                 echo "Waiting for peertube to start before running background migrations..."
                 while ! grep :2328 /proc/1/net/tcp > /dev/null && ! grep :2328 /proc/1/net/tcp6 > /dev/null; do
                   sleep 1
-                end
+                done
                 echo "Running migrations in background..."
                 find dist/scripts/migrations/ -iname '*.js' | xargs -rn1 node
                 echo "Background migrations have finished."


### PR DESCRIPTION
fixes below error in the peertube container

```
Stream closed EOF for peertube/peertube-7f98dc97bc-mjmz4 (config-ensure)
peertube bash: -c: line 9: syntax error near unexpected token `)'
peertube bash: -c: line 9: `) &'
Stream closed EOF for peertube/peertube-7f98dc97bc-mjmz4 (peertube)
```